### PR TITLE
Check compatible ability to use thecodingmachine/safe.

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -23,4 +23,35 @@ class Helpers
 
         return $callback($valueOrValues);
     }
+
+    /**
+     * Check compatible ability to use thecodingmachine/safe.
+     *
+     * @param string $methodName
+     * @return bool
+     */
+    public static function shouldUseSafe(string $methodName): bool
+    {
+        $safeVersion = \Composer\InstalledVersions::getVersion('thecodingmachine/safe');
+
+        $skipFunctions = [
+            'uksort',
+        ];
+
+        // Version 2.
+        if (version_compare($safeVersion, '2', '>='))
+        {
+            if (in_array($methodName, $skipFunctions))
+            {
+                return false;
+            }
+        }
+
+        if (!is_callable('\\Safe\\' . $methodName))
+        {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/Support/AliasArguments/ArrayKeyChange.php
+++ b/src/Support/AliasArguments/ArrayKeyChange.php
@@ -3,6 +3,8 @@
 declare(strict_types = 1);
 namespace Rebing\GraphQL\Support\AliasArguments;
 
+use Rebing\GraphQL\Helpers;
+
 class ArrayKeyChange
 {
     public function modify(array $array, array $pathKeyMappings): array
@@ -21,9 +23,15 @@ class ArrayKeyChange
      */
     private function orderPaths(array $paths): array
     {
-        \Safe\uksort($paths, function (string $a, string $b): int {
+        $callback = function (string $a, string $b): int {
             return $this->pathLevels($b) <=> $this->pathLevels($a);
-        });
+        };
+
+        if (Helpers::shouldUseSafe('uksort')) {
+            \Safe\uksort($paths, $callback);
+        } else {
+            uksort($paths, $callback);
+        }
 
         return $paths;
     }


### PR DESCRIPTION
 vendor\bin\phpunit tests/Unit/AliasArguments/AliasArgumentsTest.php
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.                                                                   1 / 1 (100%)

Time: 00:00.294, Memory: 24.00 MB

OK (1 test, 1 assertion)

Please run phpstan and do some further check.
Worked on PHP 8. Please check PHP 7.
